### PR TITLE
feat: fix Deno Deploy compatibility 

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,7 @@
     "format": "deno fmt",
     "lint": "deno lint",
     "check": "deno fmt --check && deno lint",
-    "run": "deno run --allow-env --allow-net main.ts"
+    "run": "deno run --allow-env --allow-net --allow-read=.env main.ts",
+    "manifest": "deno run --allow-read --allow-write --allow-run manifest.ts"
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -22,7 +22,7 @@ if (typeof Deno.env.get("DENO_DEPLOYMENT_ID") === "undefined") {
 const app = new Application();
 const router = new Router();
 
-await populateRouter(router, "./routes");
+await populateRouter(router);
 
 app.use(router.routes());
 app.use(router.allowedMethods());

--- a/main.ts
+++ b/main.ts
@@ -1,10 +1,27 @@
 import { Application, Router } from "https://deno.land/x/oak@v10.5.1/mod.ts";
+import { parse } from "https://deno.land/x/dot_env@0.2.0/mod.ts";
 import { populateRouter } from "./routing.ts";
+
+if (typeof Deno.env.get("DENO_DEPLOYMENT_ID") === "undefined") {
+  try {
+    const env = parse(await Deno.readTextFile(".env"));
+    for (const key in env) {
+      if (Object.prototype.hasOwnProperty.call(env, key)) {
+        Deno.env.set(key, env[key]);
+      }
+    }
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      console.log("No .env file found");
+    } else {
+      throw e;
+    }
+  }
+}
 
 const app = new Application();
 const router = new Router();
 
-await import("https://deno.land/x/dotenv@v3.2.0/load.ts");
 await populateRouter(router, "./routes");
 
 app.use(router.routes());

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,0 +1,74 @@
+// Uses code derived/adapted from lucacasonato/fresh, which is licensed under the MIT License
+import {
+  join,
+  resolve,
+  toFileUrl,
+} from "https://deno.land/std@0.128.0/path/mod.ts";
+import { walk } from "https://deno.land/std@0.128.0/fs/walk.ts";
+
+const directory = resolve("./");
+const routes = [];
+try {
+  const routesDir = join(directory, "./routes");
+  const routesUrl = toFileUrl(routesDir);
+  for await (const _ of Deno.readDir(routesDir)) {
+    // do nothing
+  }
+  const routesFolder = walk(routesDir, {
+    includeDirs: false,
+    includeFiles: true,
+    exts: ["ts"],
+  });
+
+  for await (const entry of routesFolder) {
+    if (entry.isFile) {
+      const file = toFileUrl(entry.path).href.substring(
+        routesUrl.href.length,
+      );
+      routes.push(file);
+    }
+  }
+} catch (err) {
+  if (err instanceof Deno.errors.NotFound) {
+    // Do nothing.
+  } else {
+    throw err;
+  }
+}
+routes.sort();
+
+const output =
+  `// DO NOT EDIT. This file is generated automatically by \`deno task manifest\`.
+// This file SHOULD be checked into source version control.
+${
+    routes.map((file, i) => `import * as $${i} from "./routes${file}";`).join(
+      "\n",
+    )
+  }
+
+export const manifest = {
+routes: {
+  ${
+    routes.map((file, i) => `${JSON.stringify(`./routes${file}`)}: $${i},`)
+      .join("\n    ")
+  }
+},
+baseUrl: import.meta.url,
+};
+`;
+
+const manifestPath = join(directory, "./routes.gen.ts");
+await Deno.writeTextFile(manifestPath, output);
+const proc = Deno.run({
+  cmd: [Deno.execPath(), "fmt", manifestPath],
+  stdin: "null",
+  stdout: "null",
+  stderr: "null",
+});
+await proc.status();
+proc.close();
+
+console.log(
+  `%cThe manifest has been generated for ${routes.length} routes.`,
+  "color: blue; font-weight: bold",
+);

--- a/routes.gen.ts
+++ b/routes.gen.ts
@@ -1,0 +1,10 @@
+// DO NOT EDIT. This file is generated automatically by `deno task manifest`.
+// This file SHOULD be checked into source version control.
+import * as $0 from "./routes/index.ts";
+
+export const manifest = {
+  routes: {
+    "./routes/index.ts": $0,
+  },
+  baseUrl: import.meta.url,
+};

--- a/routing.ts
+++ b/routing.ts
@@ -1,4 +1,6 @@
 import { Router } from "https://deno.land/x/oak@v10.5.1/mod.ts";
+import { cyan } from "https://deno.land/std@0.128.0/fmt/colors.ts";
+import { manifest } from "./routes.gen.ts";
 
 export const handlerTypes = [
   "GET",
@@ -7,36 +9,43 @@ export const handlerTypes = [
   "DELETE",
 ];
 
-export async function populateRouter(
+export function populateRouter(
   router: Router,
-  baseDirectory: string,
-): Promise<void> {
-  for await (const entry of Deno.readDir(baseDirectory)) {
-    if (entry.isFile) {
-      const file = await import(`${baseDirectory}/${entry.name}`);
+): void {
+  for (const routeObject in manifest.routes) {
+    if (Object.prototype.hasOwnProperty.call(manifest.routes, routeObject)) {
+      //@ts-ignore: TypeScript is having a hissy fit, everything is fine :)
+      const element = manifest.routes[routeObject];
 
-      if (typeof file.handler !== "undefined") {
+      if (typeof element.handler !== "undefined") {
         for (const handlerType of handlerTypes) {
-          if (typeof file.handler[handlerType] !== "undefined") {
+          if (typeof element.handler[handlerType] !== "undefined") {
             switch (handlerType) {
               case "GET":
-                router.get(file.handler.path, file.handler[handlerType]);
+                router.get(element.handler.path, element.handler[handlerType]);
                 break;
               case "POST":
-                router.post(file.handler.path, file.handler[handlerType]);
+                router.post(element.handler.path, element.handler[handlerType]);
                 break;
               case "PUT":
-                router.put(file.handler.path, file.handler[handlerType]);
+                router.put(element.handler.path, element.handler[handlerType]);
                 break;
               case "DELETE":
-                router.delete(file.handler.path, file.handler[handlerType]);
+                router.delete(
+                  element.handler.path,
+                  element.handler[handlerType],
+                );
                 break;
             }
+
+            console.log(
+              `Registered ${cyan(handlerType)} route with path ${
+                cyan(element.handler.path)
+              }`,
+            );
           }
         }
       }
-    } else if (entry.isDirectory) {
-      await populateRouter(router, `${baseDirectory}/${entry.name}`);
     }
   }
 }


### PR DESCRIPTION
- Use a different method to parse .env files
- Use a routes.gen.ts file generated by deno task manifest, rather than dynamic imports